### PR TITLE
요청 URL 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,6 @@
 .env.development.local
 .env.test.local
 .env.production.local
-.env.development
-.env.production
 
 npm-debug.log*
 yarn-debug.log*

--- a/back-end/src/index.ts
+++ b/back-end/src/index.ts
@@ -18,6 +18,7 @@ const app = express();
 const httpServer = createServer(app);
 const io = new Server(httpServer, {
   cors: { origin: '*' },
+  path: '/socket',
 });
 
 socketUtil(io);
@@ -37,8 +38,8 @@ app.use(
   })
 );
 
-app.use('/users', userRouter);
-app.use('/', indexRouter);
+app.use('/api/users', userRouter);
+app.use('/api', indexRouter);
 
 app.use(express.static(path.join(__dirname, '../build')));
 

--- a/back-end/src/route/indexRouter.ts
+++ b/back-end/src/route/indexRouter.ts
@@ -28,14 +28,10 @@ indexRouter.post('/non-login', async (req: Request, res: Response, next: NextFun
   }
 });
 
-indexRouter.get('/test', async (req: Request, res: Response, next: NextFunction) => {
-  res.json('test');
-});
+// indexRouter.get('/*', async (req: Request, res: Response, next: NextFunction) => {
+//   const htmlPath = path.join(__dirname, '../../build/index.html');
 
-indexRouter.get('/*', async (req: Request, res: Response, next: NextFunction) => {
-  const htmlPath = path.join(__dirname, '../../build/index.html');
-
-  res.sendFile(htmlPath);
-});
+//   res.sendFile(htmlPath);
+// });
 
 export default indexRouter;

--- a/front-end/.env.development
+++ b/front-end/.env.development
@@ -1,1 +1,1 @@
-SOCKET_HOST=localhost:5000
+REACT_APP_SOCKET_HOST=localhost:5000

--- a/front-end/.env.production
+++ b/front-end/.env.production
@@ -1,1 +1,1 @@
-SOCKET_HOST=liarking.kro.kr
+REACT_APP_SOCKET_HOST=liarking.kro.kr

--- a/front-end/src/App.tsx
+++ b/front-end/src/App.tsx
@@ -10,7 +10,7 @@ import io from 'socket.io-client';
 
 export const globalContext = React.createContext(null);
 
-const global = { popModal: {}, user: {}, socket: io(process.env.SOCKET_HOST) };
+const global = { popModal: {}, user: {}, socket: io(process.env.REAC_APP_SOCKET_HOST, { path: '/socket' }) };
 
 function App() {
   const [modal, setModal] = useState([]);

--- a/front-end/src/components/Lobby/CreateRankModal.tsx
+++ b/front-end/src/components/Lobby/CreateRankModal.tsx
@@ -22,7 +22,7 @@ const CreateRankModal = ({ offModal }: { offModal(): void }) => {
 
   useEffect(() => {
     const getRanks = async () => {
-      const _ranks: any = await fetch('/users/ranks');
+      const _ranks: any = await fetch('/api/users/ranks');
       const ranks: any = await _ranks.json();
       setRanks(ranks);
     };

--- a/front-end/src/components/Main/JoinButton.tsx
+++ b/front-end/src/components/Main/JoinButton.tsx
@@ -80,7 +80,7 @@ const JoinModal = () => {
         password: userInfo['pwd'],
       }),
     };
-    const data = await fetch('/users', options);
+    const data = await fetch('/api/users', options);
     const user = await data.json(); // return [object: 유저정보 | false: 아이디 중복]
 
     return user;

--- a/front-end/src/components/Main/LoginButton.tsx
+++ b/front-end/src/components/Main/LoginButton.tsx
@@ -63,7 +63,7 @@ const LoginModal = () => {
         password: userInfo['pwd'],
       }),
     };
-    const data = await fetch('/login', options);
+    const data = await fetch('/api/login', options);
     const user = await data.json(); // return [object: 유저정보 | false: 로그인 실패]
 
     return user;

--- a/front-end/src/components/Main/NoLoginButton.tsx
+++ b/front-end/src/components/Main/NoLoginButton.tsx
@@ -52,7 +52,7 @@ const NoLoginModal = () => {
       }),
     };
 
-    const data = await fetch('/non-login', options);
+    const data = await fetch('/api/non-login', options);
     const user = await data.json(); // return Boolean, true: 아이디 사용가능, false: 아이디 중복
 
     return user;


### PR DESCRIPTION
- 서버와 클라이언트 분리를 위한 URL 변경
- api는 요청 주소 앞에 /api 를 붙임 ( /login => /api/login )
- 소켓은 주소 뒤에 /socket가 붙음 ( io('/', { path: "/socket" } )

주소를 변경한 이유는 nginx에서 index.html은 '/'로 렌더링하기 때문
/login은 /api/login으로 변경하고 nginx에서 /api를 백엔드 서버로 리버스 프록시 함