### PR TITLE
게임 방 코드 리펙토링 및 기능업데이트 수행

### DIFF
--- a/back-end/src/utils/socket/gameRoom.ts
+++ b/back-end/src/utils/socket/gameRoom.ts
@@ -1,5 +1,5 @@
 import { Server, Socket } from 'socket.io';
-import { roomList, socketUser } from '../../store/store';
+import { roomList } from '../../store/store';
 
 /**
  * 유저가 레디버튼을 클릭 하였을 때 상태를 서버에서 전파
@@ -7,8 +7,6 @@ import { roomList, socketUser } from '../../store/store';
 const sendUserReady = (socket: Socket, io: Server) => {
   socket.on('user ready', (title: string) => {
     const roomInfo = roomList.get(title);
-
-    console.log(roomList.get(title));
 
     roomInfo.client = roomInfo.client.map((v: { socketId: string; state: string; name: string }) => {
       if (v.socketId === socket.id) {
@@ -23,7 +21,7 @@ const sendUserReady = (socket: Socket, io: Server) => {
 
     roomList.set(title, roomInfo);
 
-    io.to(title).emit('user ready', roomInfo);
+    io.to(title).emit('room data', { roomInfo: roomInfo, tag: 'user ready' });
   });
 };
 

--- a/back-end/src/utils/socket/lobbyRoom.ts
+++ b/back-end/src/utils/socket/lobbyRoom.ts
@@ -68,7 +68,7 @@ const sendRoomJoin = (socket: Socket, io: Server) => {
  */
 const sendRoomData = (socket: Socket, io: Server) => {
   socket.on('room data', (title: string) => {
-    io.to(title).emit('room data', roomList.get(title));
+    io.to(title).emit('room data', { roomInfo: roomList.get(title), tag: 'default' });
   });
 };
 
@@ -85,7 +85,7 @@ const sendRoomExit = (socket: Socket, io: Server) => {
     if (roomInfo && roomInfo.client.length > 1) {
       const client = roomInfo.client.filter((user: { socketId: string; name: string }) => user.socketId !== socket.id);
       roomList.set(title, { ...roomInfo, client });
-      io.to(title).emit('room exit', roomList.get(title));
+      io.to(title).emit('room data', { roomInfo: roomList.get(title), tag: 'room exit' });
     } else {
       roomList.delete(title);
     }
@@ -108,7 +108,7 @@ const sendDisconnect = (socket: Socket, io: Server) => {
         roomList.delete(roomTitle);
       } else {
         roomList.set(roomTitle, { ...roomInfo, client: newClients });
-        io.to(roomTitle).emit('user disconnected', roomList.get(roomTitle));
+        io.to(roomTitle).emit('room data', { roomInfo: roomList.get(roomTitle), tag: 'user disconnected' });
       }
       io.to('lobby').emit('room list', Array.from(roomList));
     }

--- a/front-end/src/components/Game/GameButtons.tsx
+++ b/front-end/src/components/Game/GameButtons.tsx
@@ -1,11 +1,13 @@
 import React, { useState, useContext } from 'react';
 import { useHistory } from 'react-router';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { globalContext } from '../../App';
 import globalAtom from '../../recoilStore/globalAtom';
+import globalSelector from '../../recoilStore/globalSelector';
+import { modalPropsType } from '../public/Modal';
 
 import GameRoomSettings from './GameRoomSettings';
-export type GameButtonsPropsType = { isOwner: boolean; gameSetting?: () => void; gameStart?: () => void; gameReady?: () => void };
+export type GameButtonsPropsType = { isOwner: boolean; isAllReady?: boolean; isReady?: boolean; roomTitle: string };
 
 const GameButtons = (props: GameButtonsPropsType) => {
   const { isOwner } = props;
@@ -13,6 +15,7 @@ const GameButtons = (props: GameButtonsPropsType) => {
   const [settingsModal, setSettingsModal] = useState([]);
   const { socket } = useContext(globalContext);
   const { selectedRoomTitle } = useRecoilValue(globalAtom.roomData);
+  const popModal: (modalProps: modalPropsType) => void = useSetRecoilState(globalSelector.popModal);
 
   const offModal = () => {
     setSettingsModal([]);
@@ -28,25 +31,39 @@ const GameButtons = (props: GameButtonsPropsType) => {
     setSettingsModal([ModalOutLocation, <GameRoomSettings offModal={offModal} key={1} />]);
   };
 
+  const roomGameStart = () => {
+    if (!props.isAllReady) {
+      popModal({ type: 'error', ment: '아직 준비가 되지않은 플레이어가 있습니다.' });
+      return;
+    }
+    //game 시작하기 버튼
+  };
+
+  const roomGameReady = () => {
+    socket.emit('user ready', props.roomTitle);
+  };
+
   return (
     <div className="game-header-buttons">
       {isOwner && (
-        <button className="game-header-button" onClick={roomSettings}>
-          게임 설정
-        </button>
+        <>
+          <button className="game-header-button" onClick={roomSettings}>
+            게임 설정
+          </button>
+          {settingsModal}
+        </>
       )}
       {isOwner && (
-        <button className="game-header-button" onClick={props.gameStart}>
+        <button className={`game-header-button ${!props.isAllReady ? 'not-ready-to-start' : ''}`} onClick={roomGameStart}>
           게임 시작
         </button>
       )}
       {!isOwner && (
-        <button className="game-header-button" onClick={props.gameReady}>
-          준비 완료
+        <button className="game-header-button" onClick={roomGameReady}>
+          {props.isReady ? '준비 완료' : '준비 하기'}
         </button>
       )}
       <div className="game-header-button-exit" onClick={exit} />
-      {settingsModal}
     </div>
   );
 };

--- a/front-end/src/components/Game/GameContent.tsx
+++ b/front-end/src/components/Game/GameContent.tsx
@@ -1,27 +1,27 @@
 import React, { useEffect, useReducer } from 'react';
+import { roomInfoType } from '../pages/Game';
 import GameContentChat from './GameContentChat';
 import GameContentLiar from './GameContentLiar';
 import GameContentResult from './GameContentResult';
 import GameContentSelect from './GameContentSelect';
 import GameContentVote from './GameContentVote';
 
-export type actionType = (
+export type actionType =
   | { type: 'waiting' }
   | { type: 'select'; select: { word: string } }
   | { type: 'chat'; chat: { chatHistory: string[]; speaker: string; timer: number } }
   | { type: 'vote'; vote: { timer: number } }
   | { type: 'result'; result: { voteResult: string[]; liar: string; gameResult: boolean } }
-  | { type: 'liar'; liar: { category: string[]; answer: number; success(): void; fail(): void } }
-) & { persons: Array<{ id: string; state: string }> };
+  | { type: 'liar'; liar: { category: string[]; answer: number; success(): void; fail(): void } };
 
-const $reducer = (state: JSX.Element, action: actionType): JSX.Element => {
+const $reducer = (state: JSX.Element, action: actionType & roomInfoType): JSX.Element => {
   switch (action.type) {
     case 'waiting':
       return <></>;
     case 'select':
       return <GameContentSelect select={action.select} />;
     case 'chat':
-      return <GameContentChat persons={action.persons} chat={action.chat} />;
+      return <GameContentChat clients={action.client} chat={action.chat} />;
     case 'vote':
       return <GameContentVote timer={action.vote.timer} />;
     case 'result':
@@ -33,7 +33,7 @@ const $reducer = (state: JSX.Element, action: actionType): JSX.Element => {
   }
 };
 
-const GameContent = ({ action }: { action: actionType }) => {
+const GameContent = ({ action }: { action: actionType & roomInfoType }) => {
   const [$, $dispatch] = useReducer($reducer, <></>);
 
   useEffect(() => {

--- a/front-end/src/components/Game/GameContentChat.tsx
+++ b/front-end/src/components/Game/GameContentChat.tsx
@@ -3,12 +3,13 @@ import { useRecoilValue } from 'recoil';
 import { Socket } from 'socket.io-client';
 import { globalContext } from '../../App';
 import globalAtom from '../../recoilStore/globalAtom';
+import { clientType } from './GamePersons';
 
 type propsType = { chatHistory: string[]; speaker: string; timer: number };
 
 const chatColor = ['white', 'red', 'orange', 'yellow', 'green', 'blue', 'navy', 'purple'];
 
-const GameContentChat = ({ persons, chat }: { persons: Array<{ id: string; item?: string }>; chat: propsType }) => {
+const GameContentChat = ({ clients, chat }: { clients: clientType[]; chat: propsType }) => {
   const user = useRecoilValue(globalAtom.user);
   const roomData = useRecoilValue(globalAtom.roomData);
 
@@ -20,8 +21,8 @@ const GameContentChat = ({ persons, chat }: { persons: Array<{ id: string; item?
   const messageBox = useRef<HTMLInputElement>();
 
   const idList: Array<string> = [];
-  persons.forEach((person) => {
-    idList.push(person.id);
+  clients.forEach((client) => {
+    idList.push(client.name);
   });
 
   const changeMessage = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/front-end/src/components/Game/GamePersons.tsx
+++ b/front-end/src/components/Game/GamePersons.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
 
-export type personType = { id: string; state: string };
+export type clientType = { name: string; state: string };
 
-const GamePersons = ({ persons }: { persons: personType[] }) => {
-  const [person, setPerson] = useState(new Array(8).fill(<div />));
+const GamePersons = ({ clients }: { clients: clientType[] }) => {
+  const [client, setClient] = useState(new Array(8).fill(<div />));
 
   const getStateComponent = (state: string) => {
     switch (state) {
@@ -15,25 +15,25 @@ const GamePersons = ({ persons }: { persons: personType[] }) => {
   };
 
   useEffect(() => {
-    setPerson(
-      person.map((v, i) => {
+    setClient(
+      client.map((v, i) => {
         return (
           <>
             <div className="game-persons-user-character">
-              <div className="game-user-id">{persons[i]?.id ?? ''}</div>
-              <div className={persons[i] ? 'game-user-character' : ''} />
+              <div className="game-user-id">{clients[i]?.name ?? ''}</div>
+              <div className={clients[i] ? 'game-user-character' : ''} />
             </div>
-            <div className="game-persons-user-item">{getStateComponent(persons[i]?.state ?? '')}</div>
+            <div className="game-persons-user-item">{getStateComponent(clients[i]?.state ?? '')}</div>
           </>
         );
       })
     );
-  }, [persons]);
+  }, [clients]);
 
   return (
     <>
       <div className="game-persons-left">
-        {person
+        {client
           .filter((v, i) => i < 4)
           .map((v, i) => (
             <div className="game-persons-user game-persons-user-left" key={i}>
@@ -42,7 +42,7 @@ const GamePersons = ({ persons }: { persons: personType[] }) => {
           ))}
       </div>
       <div className="game-persons-right">
-        {person
+        {client
           .filter((v, i) => i >= 4)
           .map((v, i) => (
             <div className="game-persons-user game-persons-user-right" key={i}>

--- a/front-end/src/components/pages/Game.tsx
+++ b/front-end/src/components/pages/Game.tsx
@@ -77,37 +77,17 @@ const Game = () => {
   useEffect(() => {
     if (!user.user_id) getUserData(setUser);
 
-    socket.on('room data', (roomInfo: roomInfoType) => {
-      setRoomInfo(roomInfo);
+    socket.on('room data', ({ roomInfo, tag }: { roomInfo: roomInfoType; tag: string }) => {
+      console.log('tag:', tag);
+      console.log('roomInfo:', roomInfo);
 
-      console.log('누군가 입장했습니다', roomInfo);
+      setRoomInfo(roomInfo);
     });
 
     socket.emit('room data', roomData.selectedRoomTitle);
 
-    socket.on('room exit', (roomInfo: roomInfoType) => {
-      setRoomInfo(roomInfo);
-
-      console.log('누군가 방에서 나갔습니다', roomInfo);
-    });
-
-    socket.on('user disconnected', (roomInfo: roomInfoType) => {
-      setRoomInfo(roomInfo);
-
-      console.log('누군가 방에서 팅겼습니다', roomInfo);
-    });
-
-    socket.on('user ready', (roomInfo: roomInfoType) => {
-      setRoomInfo(roomInfo);
-
-      console.log('누군가 레디버튼을 클릭했습니다.');
-    });
-
     return () => {
       socket.off('room data');
-      socket.off('room exit');
-      socket.off('user disconnected');
-      socket.off('user ready');
     };
   }, []);
 

--- a/front-end/src/recoilStore/globalSelector.tsx
+++ b/front-end/src/recoilStore/globalSelector.tsx
@@ -7,7 +7,6 @@ const globalSelector = {
     key: 'popModal',
     get: ({ get }) => get(globalAtom.modal),
     set: ({ set }, modalprops: modalPropsType) => {
-      console.log(globalAtom.modal);
       set(globalAtom.modal, <Modal modalProps={modalprops} />);
     },
   }),

--- a/front-end/src/styles/Game.css
+++ b/front-end/src/styles/Game.css
@@ -68,6 +68,10 @@
   align-items: center;
 }
 
+.game-header-buttons > .not-ready-to-start {
+  filter: opacity(0.6) !important;
+}
+
 .game-header-button {
   width: auto;
   min-width: fit-content;
@@ -82,6 +86,11 @@
   margin: 0 20px;
   text-shadow: 2px 3px 2px gray;
   box-shadow: 3px 6px 10px rgba(0, 0, 0, 0.5);
+  transition: filter 0.3s;
+}
+
+.game-header-button:hover {
+  filter: brightness(0.8);
 }
 
 .game-header-button-exit {

--- a/front-end/src/styles/Modal.css
+++ b/front-end/src/styles/Modal.css
@@ -7,6 +7,7 @@
   top: 0;
   width: 100vw;
   height: 100vh;
+  z-index: 99;
 }
 
 #modal {
@@ -19,6 +20,7 @@
   background-color: #a7bdd9;
   padding: 30px;
   animation: fadeIn 2s ease-in-out forwards;
+  z-index: 100;
 }
 
 @keyframes fadeIn {


### PR DESCRIPTION
- 게임 방 페이지 클라이언트 소켓 압축
- 방의 UI 변경을 요구하는 데이터는 모두 `room data`로 오도록 수정함.
- 클라이언트의 준비 버튼 클릭시 준비완료, 준비하기 멘트변경.
- 클라이언트가 전부 준비상태가 되었을때 방장의 게임시작 버튼 활성화.
- 버튼 css 수정. 마우스호버 애니메이션.
- persons 타입, 값 제거. roomInfo의 client로 대체.
  - 변경으로 인한 전체 코드 수정작업 수행.
- popModal의 콘솔로그 제거.
- popModal z-index 99, 100 으로 변경.