### PR TITLE
말풍선 꼬리 잘리는 버그 수정

### DIFF
--- a/front-end/src/components/Game/GameChatBox.tsx
+++ b/front-end/src/components/Game/GameChatBox.tsx
@@ -15,6 +15,7 @@ const CONSTANTS = {
   CHATBOX_TOP_DIFF: 19,
   ROW_MAX_CLIENT: 4,
   CURRENT_CHAT_IDX: 0,
+  MSG_BOX_APPEAR_TIME: 3000,
 };
 
 type chatListType = {
@@ -47,7 +48,6 @@ const GameChatBox = () => {
   const { socket }: { socket: socketUtilType } = useContext(globalContext);
 
   const myClassName = 'my-bubble-box';
-
   let clientIdx = clients.length;
 
   clients.map((client, i) => {
@@ -60,16 +60,13 @@ const GameChatBox = () => {
 
   const sendMessage = () => {
     if (messageBox.current.value === '') return;
-
     const messageInfo = { userId: user.user_id, message: messageBox.current.value, title: roomData.selectedRoomTitle, clientIdx: clientIdx };
-
     socket.emit.WAIT_ROOM_MESSAGE(messageInfo);
     messageBox.current.value = '';
   };
 
   const setBubbleBox = (messageInfo: { userId: string; message: string; clientIdx: number }) => {
     let bubbleClassName = 'bubble-left';
-
     if (messageInfo.clientIdx >= CONSTANTS.ROW_MAX_CLIENT) {
       bubbleClassName = 'bubble-right';
     }
@@ -80,18 +77,16 @@ const GameChatBox = () => {
         className={bubbleClassName + ' ' + (messageInfo.clientIdx === clientIdx ? myClassName : '')}
         key={messageInfo.clientIdx}
       >
-        {messageInfo.message}
+        <div className="bubble-chat-box-msg">{messageInfo.message}</div>
       </div>
     );
 
     chatList[messageInfo.clientIdx].unshift(updateModal);
-
     setModal({ ...chatList });
-
     setTimeout(() => {
       chatList[messageInfo.clientIdx].splice(chatList[messageInfo.clientIdx].length - 2, 1);
       setModal({ ...chatList });
-    }, 3000);
+    }, CONSTANTS.MSG_BOX_APPEAR_TIME);
   };
 
   useEffect(() => {

--- a/front-end/src/styles/GameChatBox.css
+++ b/front-end/src/styles/GameChatBox.css
@@ -1,22 +1,13 @@
 #bubble-chat-box {
-  position: absolute;
+  position: relative;
   width: 250px;
   height: 100px;
   padding: 0.3vh 1vw;
-  background: #ffffff;
+  background: #fff;
   -webkit-border-radius: 10px;
   -moz-border-radius: 10px;
   border-radius: 10px;
-  word-break: break-all;
   box-shadow: 5px 10px 10px rgba(0, 0, 0, 0.5);
-  text-shadow: 1px 2px 2px rgba(0, 0, 0, 0.2);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 4;
-  -webkit-box-orient: vertical;
-  line-height: 25px;
-  font-weight: 600;
 }
 
 .game-wait-chat-bubble-box {
@@ -25,15 +16,27 @@
   height: 100px;
 }
 
+.bubble-chat-box-msg {
+  text-shadow: 1px 2px 2px rgba(0, 0, 0, 0.2);
+  text-overflow: ellipsis;
+  font-weight: 600;
+  word-break: break-all;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow-y: hidden;
+  line-height: 25px;
+}
+
 .bubble-left:after {
   content: '';
   position: absolute;
   border-style: solid;
   border-width: 20px 15px 20px 0;
-  border-color: transparent #ffffff;
+  border-color: transparent #fff;
+  z-index: 1;
   display: block;
   width: 0;
-  z-index: 1;
   left: -15px;
   top: 23px;
 }
@@ -43,7 +46,7 @@
   position: absolute;
   border-style: solid;
   border-width: 20px 0 20px 15px;
-  border-color: transparent #ffffff;
+  border-color: transparent #fff;
   display: block;
   width: 0;
   z-index: 1;


### PR DESCRIPTION
게임페이지 내 채팅 말풍선의 꼬리 잘리는 버그 수정
- [x] 메시지 text의 길이가 길면 숨기기 위해 overflow:hidden을 적용한 것이 말풍선 꼬리 (:after) 속성까지 적용되어 생긴 버그
- [x] GameChatBox 컴포넌트의 updateModal(채팅말풍선)에 메시지 텍스트를 div로 나눠준 후 overflow를 따로 적용하여 해결