### PR TITLE
점수 업데이트 버그, CreateRoomModal 세팅값 개선

### DIFF
--- a/front-end/src/components/Game/GameContentResult.tsx
+++ b/front-end/src/components/Game/GameContentResult.tsx
@@ -53,7 +53,7 @@ const GameContentResult = () => {
       sendPoint = resultData.liarWins ? CONSTANTS.SUBTRACT_TEN : CONSTANTS.ADD_TEN;
       setPointComment(sendPoint);
     }
-    if (user.rank !== CONSTANTS.UNRANKED && !fetchLock) requestToServer();
+    if (resultData.liar && user.rank !== CONSTANTS.UNRANKED && !fetchLock) requestToServer();
     setFetchLock(false);
   }, [resultData]);
 

--- a/front-end/src/components/Lobby/CreateRoomModal.tsx
+++ b/front-end/src/components/Lobby/CreateRoomModal.tsx
@@ -30,8 +30,8 @@ const CreateRoomModal = ({ offModal }: { offModal(): void }) => {
   const [roomInfo, setRoomInfo] = useState({
     title: '',
     password: '',
-    max: 1,
-    cycle: 1,
+    max: 8,
+    cycle: 2,
     owner: user.user_id,
   });
   const history = useHistory();
@@ -54,7 +54,7 @@ const CreateRoomModal = ({ offModal }: { offModal(): void }) => {
   };
 
   const decreasePersons = () => {
-    if (roomInfo.max > 1) {
+    if (roomInfo.max > 2) {
       setRoomInfo({ ...roomInfo, max: roomInfo.max - 1 });
     }
   };


### PR DESCRIPTION
점수 업데이트 fetch 2번 보내는 오류: 투표 완료 시에도 fetch 요청을 보내는 것이 원인
-> 투표 완료 시에는 요청을 보내지는 않고 최종 결과 나왔을 때만 fetch 보냄
CreateRoomModal : 기본 인원 수 8, 최소 최대 인원 수 3, 라운드 수 2로 수정