### PR TITLE
body 태그 overflow-y 속성 부여

### DIFF
--- a/front-end/src/styles/App.css
+++ b/front-end/src/styles/App.css
@@ -1,3 +1,7 @@
+body {
+  overflow-y: scroll;
+}
+
 .page-slider-enter {
   opacity: 0.01;
 }


### PR DESCRIPTION
모바일 주소창때문에 생기는 버그 수정 (주소창에 가려 오류 발생)
- body 태그 overflow-y: scroll 속성 부여